### PR TITLE
docs: better translation

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
-特此授予任何人免费或有偿使用、复制、修改和/或分发本软件的许可，但前提是所有副本中都必须包含上述版权声明和本许可声明。
+特此授予任何人免费或收费使用、复制、修改和/或分发本软件的权限，前提是上述版权声明和本许可声明必须包含在所有副本中。
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is an interactive title logo that allows users to change its colors
 
 ## Features (功能)
 * **Interactive Color Adjustment**: Users can adjust RGB color sliders to change the colors of the title logo.
-    * **交互式颜色调整**: 用户可以通过调整 RGB 滑块来改变标题徽标的颜色。
+    * **交互式颜色调节**: 用户可以通过调节 RGB 颜色滑块来改变标题徽标的颜色。
 * **Dynamic Gradient Mode**: Clicking the title logo toggles a dynamic gradient effect.
     * **动态渐变模式**: 点击标题徽标可以切换动态渐变效果。
 * **Responsive Design**: The canvas adjusts its size based on screen orientation (landscape or portrait).
@@ -23,7 +23,7 @@ This project is an interactive title logo that allows users to change its colors
 
 Adjust the sliders to change the colors. Click the title logo to toggle the gradient mode.
 
-调整滑块来改变颜色。点击标题徽标以切换渐变模式。
+调节滑块来改变颜色。点击标题徽标以切换渐变模式。
 
 ## Roadmap (路线图)
 
@@ -35,13 +35,13 @@ This interactive logo is a proof of concept for a future game engine called the 
 
 This project is licensed under the ISC License.
 
-本项目根据 ISC 许可证授权。
+本项目采用 ISC 许可证进行授权。
 
 **Copyright (版权所有) 2025 Kenny Fully (2025年, 肯尼)**
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
-特此授予任何人免费或有偿使用、复制、修改和/或分发本软件的许可，但前提是所有副本中都必须包含上述版权声明和本许可声明。
+特此授予任何人免费或收费使用、复制、修改和/或分发本软件的权限，前提是上述版权声明和本许可声明必须包含在所有副本中。
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 


### PR DESCRIPTION
- `调整` -> `调节`
The [meaning](https://dictionary.cambridge.org/zhs/%E8%AF%8D%E5%85%B8/%E6%B1%89%E8%AF%AD-%E7%AE%80%E4%BD%93-%E8%8B%B1%E8%AF%AD/%E8%B0%83%E8%8A%82) of `调节` is "to change something slightly, especially to make it more correct, effective, or suitable", and seems more suitable than `调整` for a slider.

- `根据` -> `采用`
e.g. [Vue.js Chinese Docs](https://cn.vuejs.org/guide/scaling-up/testing#recommendation-2)
> Cypress **is MIT-licensed**, but some features like parallelization require a subscription to Cypress Cloud.
> Cypress **采用 MIT 许可**，但并行化等部分功能需要订阅 Cypress Cloud。
Both two words are OK, but `采用` is more widely use.

Other changes in License part have nothing to do with their meanings, but just make the sentences more fluent.

#3 