### PR TITLE
Improve rendering and performance

### DIFF
--- a/js/color_module/color_module.js
+++ b/js/color_module/color_module.js
@@ -6,18 +6,33 @@ class ColorModule {
     this.r = options?.r ?? 0
     this.g = options?.g ?? 0
     this.b = options?.b ?? 0
+    
+    // Cache Path2D objects to avoid creating them every frame
+    this.pathColorLabel = new Path2D(`m ${(this.id % 2) * 160 + 5},141 v 2 h -4 v 2 h 2 v 2 h -2 v 12 h 2 v -2 h 2 v -2 h -2 v -2 h 2 v -2 h -2 v -2 h 2 v 2 h 2 v -2 h 4 v 4 h 2 v -6 h 4 v 2 h -2 v 6 h 2 v -2 h 2 v -8 h -4 v -2 h 4 v -2 h -8 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h 2 v -2 h -4 v -2 z m 12,14 v 4 h 2 v -4 z m -2,0 h -2 v 2 h 2 z m -2,2 h -2 v 2 h 2 z m -2,-4 h -2 v 2 h 2 z m -2,2 h -2 v 2 h 2 z m -2,2 h -2 v 2 h 2 z m 0,-2 v -2 h -2 v 2 z m 0,-2 h 2 v -2 h -2 z m 18,-12 v 2 h 6 v 2 h -6 v -2 h -2 v 2 h -2 v 2 h 2 v 12 h 16 v -4 h -2 v 2 h -12 v -4 h 12 v -8 h -4 v -2 h 2 v -2 z m -20,4 h 2 v 2 h -2 z m 20,2 h 4 v 4 h -4 z m 6,0 h 4 v 4 h -4 z`)
+    this.pathNumber1 = new Path2D(`m 48,142 v 2 h -2 v 2 h -2 v 2 h 4 v 6 h -4 v 4 h 12 v -4 h -4 v -12 z`)
+    this.pathNumber2 = new Path2D(`m 206,142 v 2 h -2 v 4 2 h 4 v -2 h 2 v 2 h -1 -1 v 1 1 h -2 v 2 h -2 v 4 h 12 v -4 h -4 v -2 h 2 v -1 -1 h 2 v -2 -4 h -2 v -2 z`)
+    
+    // Cache rectangle coordinates
+    this.outlineRect = {
+      x: (this.id % 2) * 160 + 62,
+      y: 142,
+      width: 16,
+      height: 16
+    }
+    this.colorRect = {
+      x: (this.id % 2) * 160 + 64,
+      y: 144,
+      width: 12,
+      height: 12
+    }
   }
 
   render() {
-    const pathColorLabel = new Path2D(`m ${(this.id % 2) * 160 + 5},141 v 2 h -4 v 2 h 2 v 2 h -2 v 12 h 2 v -2 h 2 v -2 h -2 v -2 h 2 v -2 h -2 v -2 h 2 v 2 h 2 v -2 h 4 v 4 h 2 v -6 h 4 v 2 h -2 v 6 h 2 v -2 h 2 v -8 h -4 v -2 h 4 v -2 h -8 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h 2 v -2 h -4 v -2 z m 12,14 v 4 h 2 v -4 z m -2,0 h -2 v 2 h 2 z m -2,2 h -2 v 2 h 2 z m -2,-4 h -2 v 2 h 2 z m -2,2 h -2 v 2 h 2 z m -2,2 h -2 v 2 h 2 z m 0,-2 v -2 h -2 v 2 z m 0,-2 h 2 v -2 h -2 z m 18,-12 v 2 h 6 v 2 h -6 v -2 h -2 v 2 h -2 v 2 h 2 v 12 h 16 v -4 h -2 v 2 h -12 v -4 h 12 v -8 h -4 v -2 h 2 v -2 z m -20,4 h 2 v 2 h -2 z m 20,2 h 4 v 4 h -4 z m 6,0 h 4 v 4 h -4 z`)
-    const pathNumber1 = new Path2D(`m 48,142 v 2 h -2 v 2 h -2 v 2 h 4 v 6 h -4 v 4 h 12 v -4 h -4 v -12 z`)
-    const pathNumber2 = new Path2D(`m 206,142 v 2 h -2 v 4 2 h 4 v -2 h 2 v 2 h -1 -1 v 1 1 h -2 v 2 h -2 v 4 h 12 v -4 h -4 v -2 h 2 v -1 -1 h 2 v -2 -4 h -2 v -2 z`)
-
     ctx.fillStyle = `rgb(38,50,56)` // gray
-    ctx.fill(pathColorLabel)
-    this.id === 0 ? ctx.fill(pathNumber1) : ctx.fill(pathNumber2)
-    ctx.fillRect((this.id % 2) * 160 + 62, 142, 16, 16) // current outline
+    ctx.fill(this.pathColorLabel)
+    ctx.fill(this.id === 0 ? this.pathNumber1 : this.pathNumber2)
+    ctx.fillRect(this.outlineRect.x, this.outlineRect.y, this.outlineRect.width, this.outlineRect.height) // current outline
     ctx.fillStyle = `rgb(${this.r},${this.g},${this.b})`
-    ctx.fillRect((this.id % 2) * 160 + 64, 144, 12, 12) // current color
+    ctx.fillRect(this.colorRect.x, this.colorRect.y, this.colorRect.width, this.colorRect.height) // current color
   }
 }

--- a/js/color_slider/color_slider.js
+++ b/js/color_slider/color_slider.js
@@ -46,11 +46,11 @@ class ColorSlider {
 
     // slider bars
     ctx.fillStyle = 'rgba(0,0,0,0.1)'
-    ctx.fillRect(20, 0, 100, 20)
+    ctx.fillRect(20, 8, 100, 4)
 
     // slider amount
     ctx.fillStyle = `rgb(${this.id % 3 === 0 ? sliderType : 32},${this.id % 3 === 1 ? sliderType : 32},${this.id % 3 === 2 ? sliderType : 32})`
-    ctx.fillRect(20, 0, (sliderType / 255) * 100, 20)
+    ctx.fillRect(20, 8, (sliderType / 255) * 100, 4)
 
     // slider handle
     ctx.translate((sliderType / 255) * 99 + 20, 0)

--- a/js/color_slider/color_slider.js
+++ b/js/color_slider/color_slider.js
@@ -53,9 +53,15 @@ class ColorSlider {
     ctx.fillRect(20, 8, (sliderType / 255) * 100, 4)
 
     // slider handle
-    ctx.translate(Math.floor((sliderType / 255) * 99) + 20, 0)  // avoid half-pixel rendering
-    ctx.fillStyle = 'rgb(255,255,255)'
+    ctx.translate(Math.floor((sliderType / 255) * 99) + 20 - 2, 0)  // avoid half-pixel rendering
+    
+    // Draw black border first
+    ctx.fillStyle = 'rgb(38,50,56)'
     ctx.fill(this.STATIC_PATH_SLIDER)
+    
+    // Draw white center
+    ctx.fillStyle = 'rgb(255,255,255)'
+    ctx.fillRect(2, 2, 2, 16)
 
     ctx.restore()
   }

--- a/js/color_slider/color_slider.js
+++ b/js/color_slider/color_slider.js
@@ -53,7 +53,7 @@ class ColorSlider {
     ctx.fillRect(20, 8, (sliderType / 255) * 100, 4)
 
     // slider handle
-    ctx.translate((sliderType / 255) * 99 + 20, 0)
+    ctx.translate(Math.floor((sliderType / 255) * 99) + 20, 0)  // avoid half-pixel rendering
     ctx.fillStyle = 'rgb(255,255,255)'
     ctx.fill(this.STATIC_PATH_SLIDER)
 

--- a/js/globals/globals.js
+++ b/js/globals/globals.js
@@ -16,3 +16,5 @@ const timers = {
   timer60: 0,
   timer60max: 59
 }
+
+ctx.imageSmoothingEnabled = false

--- a/js/title_logo/title_logo.js
+++ b/js/title_logo/title_logo.js
@@ -10,6 +10,14 @@ class TitleLogo {
     this.STATIC_STRING_OUTLINE = `v 44 h -8 v 10 h 20 v -10 -44 z m 66,0 v 4 h -30 v 12 h 12 v 6 h -2 v -4 h -10 v 10 h 4 v 4 h 4 v 4 h -4 v 8 h -4 v 10 h 10 v -4 h 4 v -4 h 20 v 4 4 h 14 v -4 h 4 v -4 -10 -4 -6 h -4 v -2 -8 -12 h -8 v -4 z m -82,14 v 12 h -4 v 6 10 h 10 v -10 h 4 v -18 z m 34,0 v 14 h 4 v 14 h 10 v -14 -6 h -4 v -8 z m 50,10 h 2 v 2 h -2 z m -14,8 h 4 v 4 h -4 z m -74,34 v 4 6 h 4 v 4 h 10 v -4 -6 h -4 v -4 z m 30,0 v 4 4 h -4 v -4 h -10 v 6 4 h 4 v 2 h -20 v 10 h 8 v 2 2 6 2 h -4 v 2 2 h -4 v 6 4 h 10 v -4 h 6 v 4 h 36 v -4 -6 h -12 v -2 -4 h 2 v 4 h 10 v -4 -6 h -4 v -2 h 4 v -2 -10 h -4 v -2 h 4 v -4 -2 -4 h -10 v 4 h -2 v -4 -4 z m 44,0 v 4 h -18 v 10 14 h 10 v -14 h 2 v 6 4 6 h -4 v 10 2 10 h 36 v -10 -2 -10 h -4 v -6 -4 -6 h 2 v 14 h 10 v -14 -10 h -16 v -4 z m 2,20 h 12 v 4 h -12 z m -58,8 h 2 v 2 h -2 z m 8,8 h 4 v 4 2 h -8 v -2 h 4 z m 48,4 h 16 v 2 h -16 z`
     this.STATIC_STRING_BODY = `v 44 h -8 v 6 h 8 8 v -50 z m 66,0 v 4 h -8 v 8 20 h 6 14 v 12 h -8 v 6 h 10 v -4 h 4 v -14 -6 h -20 v -14 h 10 v 6 h -2 v -4 h -6 v 6 h 4 v 4 h 4 6 v -12 -8 h -8 v -4 z m -30,4 v 8 h 12 v 14 h -2 v -4 h -4 v -4 h -6 v 6 h 4 v 4 h 4 v 8 h -4 v 8 h -4 v 6 h 6 v -4 h 4 v -8 h 2 v 4 h 6 v -6 h -4 v -8 h 4 v -16 -8 z m -52,10 v 12 h -4 v 12 h 6 v -10 h 4 v -14 z m 34,0 v 10 h 4 v 14 h 6 v -16 h -4 v -8 z m 40,22 v 6 h 18 v -6 z m -78,30 v 6 h 4 v 4 h 6 v -6 h -4 v -4 z m 30,0 v 16 h -14 v 8 h 10 v 2 h -6 v 4 h -4 v 6 h 6 v -4 h 6 v -4 h 2 v 12 h 6 v -16 h 12 v -8 h -12 v -16 z m 44,0 v 4 h -18 v 6 14 h 6 v -14 h 36 v 14 h 6 v -14 -6 h -16 v -4 z m -58,4 v 6 h 4 v 4 h 8 v -6 h -6 v -4 z m 26,0 v 4 h -4 v 6 h 6 v -4 h 4 v -6 z m 26,8 v 4 8 4 h 24 v -4 -8 -4 z m -68,4 v 6 h 8 v 16 h -4 v 4 h -4 v 6 h 6 v -4 h 4 v -4 h 2 v 4 h 4 v 4 h 32 v -6 h -30 v -4 h -4 v -16 -6 z m 72,0 h 16 v 8 h -16 z m -34,10 v 6 h 4 v 4 h 6 v -6 h -4 v -4 z m 26,4 v 6 6 6 h 32 v -6 -6 -6 z m 6,6 h 20 v 6 h -20 z`
     this.STATIC_STRING_HIGHLIGHT = `v 2 42 h -8 v 2 4 h 2 v -4 h 6 2 v -44 h 6 v -2 z m 66,0 v 2 2 h -8 v 2 26 h 2 v -26 h 8 v -2 -2 h 4 v -2 z m -30,4 v 2 6 h 2 v -6 h 16 v -2 z m 36,0 v 2 h 8 v -2 z m -24,8 v 14 h -2 v 2 h 2 2 v -16 z m -2,16 h -2 v 8 h -4 v 2 6 h -4 v 2 4 h 2 v -4 h 2 2 v -8 h 2 2 z m 28,-16 v 6 h -2 v 2 h 2 2 v -8 z m -2,8 h -2 v 4 h 2 z m -88,-6 v 2 10 h -4 v 2 10 h 2 v -10 h 2 2 v -12 h 4 v -2 z m 34,0 v 2 8 h 2 v -8 h 4 v -2 z m 48,0 v 2 4 h 2 v -4 h 4 v -2 z m -30,4 v 2 4 h 2 v -4 h 4 v -2 z m -12,4 v 2 h 4 v -2 z m 0,2 h -2 v 14 h 2 z m 18,-2 v 2 h 4 v -2 z m 0,2 h -2 v 4 h 2 z m 22,2 v 2 h 20 v -2 z m 14,6 v 12 h -8 v 2 4 h 2 v -4 h 6 2 v -14 z m -28,4 v 2 h 4 v -2 z m 0,2 h -2 v 4 h 2 z m 8,-2 v 2 4 h 2 v -4 h 16 v -2 z m -78,30 v 2 4 h 2 v -4 h 4 v -2 z m 30,0 v 2 14 h -14 v 2 6 h 2 v -6 h 12 2 v -16 h 4 v -2 z m 44,0 v 2 2 h -18 v 2 18 h 2 v -18 h 16 2 v -4 h 12 v -2 z m -68,4 v 2 h 4 v -2 z m 0,2 h -2 v 4 h 2 z m 10,-2 v 2 4 h 2 v -4 h 4 v -2 z m 26,0 v 2 2 h -4 v 2 4 h 2 v -4 h 2 2 v -4 h 4 v -2 z m 46,0 v 2 h 16 v -2 z m -66,4 v 2 h 6 v -2 z m 0,2 h -2 v 4 h 2 z m 76,0 v 14 h 2 v -14 z m -30,2 v 2 14 h 2 v -14 h 22 v -2 z m -68,4 v 2 4 h 2 v -4 h 12 v -2 z m 36,0 v 2 h 12 v -2 z m 52,0 v 8 h -16 v 2 h 16 2 v -10 z m -80,6 v 16 h -4 v 2 2 h -4 v 2 4 h 2 v -4 h 2 2 v -4 h 2 2 v -18 z m 18,2 v 2 h 2 v -2 z m 0,2 h -6 v 2 2 h -4 v 2 4 h 2 v -4 h 2 2 v -4 h 4 z m 12,0 v 2 4 h 2 v -4 h 4 v -2 z m -8,2 v 12 h 2 v -12 z m 14,2 v 2 h 4 v -2 z m 0,2 h -2 v 4 h 2 z m 20,-2 v 2 16 h 2 v -16 h 30 v -2 z m 26,6 v 6 h -20 v 2 h 22 v -2 -6 z m -76,2 v 2 h 4 v -2 z m 0,2 h -2 v 4 h 2 z m 4,2 v 2 h 30 v -2 z m 0,2 h -2 v 4 h 2 z`
+    
+    this.cachedOutlinePath = null
+    this.cachedBodyPath = null
+    this.cachedHighlightPath = null
+    this.lastSineResult = -1
+    
+    this.cachedGradient = null
+    this.lastGradientTime = -1
   }
 
   render(options) {
@@ -20,17 +28,30 @@ class TitleLogo {
     const moduleSet1 = moduleSets[1]
     const sineResult = sine(0, 4, timers.timer60 / timers.timer60max)
 
-    const gradient = ctx.createLinearGradient(0, 0, 120, 120)
-    gradient.addColorStop(0, `rgb(0,${sine2(127, 0, timers.timer60 / timers.timer60max)},0)`)
-    gradient.addColorStop(1, `rgb(0,${sine2(127, 255, timers.timer60 / timers.timer60max)},0)`)
+    if (this.gradientMode.active && (this.lastGradientTime !== timers.timer60 || !this.cachedGradient)) {
+      this.cachedGradient = ctx.createLinearGradient(0, 0, 120, 120)
+      this.cachedGradient.addColorStop(0, `rgb(0,${sine2(127, 0, timers.timer60 / timers.timer60max)},0)`)
+      this.cachedGradient.addColorStop(1, `rgb(0,${sine2(127, 255, timers.timer60 / timers.timer60max)},0)`)
+      this.lastGradientTime = timers.timer60
+    }
 
     ctx.fillStyle = `rgb(${moduleSet1.r},${moduleSet1.g},${moduleSet1.b})`
     ctx.fill(this.STATIC_PATH_SHADOW)
-    ctx.fill(new Path2D(`m ${22 + sineResult},0 ` + this.STATIC_STRING_OUTLINE))
-    ctx.fillStyle = this.gradientMode.active ? gradient : `rgb(${moduleSet0.r},${moduleSet0.g},${moduleSet0.b})`
-    ctx.fill(new Path2D(`m ${24 + sineResult},2 ` + this.STATIC_STRING_BODY))
+
+    if (this.lastSineResult !== sineResult) {
+      this.cachedOutlinePath = new Path2D(`m ${22 + sineResult},0 ` + this.STATIC_STRING_OUTLINE)
+      this.cachedBodyPath = new Path2D(`m ${24 + sineResult},2 ` + this.STATIC_STRING_BODY)
+      this.cachedHighlightPath = new Path2D(`m ${24 + sineResult},2 ` + this.STATIC_STRING_HIGHLIGHT)
+      this.lastSineResult = sineResult
+    }
+
+    ctx.fill(this.cachedOutlinePath)
+    
+    ctx.fillStyle = this.gradientMode.active ? this.cachedGradient : `rgb(${moduleSet0.r},${moduleSet0.g},${moduleSet0.b})`
+    ctx.fill(this.cachedBodyPath)
+    
     ctx.fillStyle = 'rgb(255,255,255)'
-    ctx.fill(new Path2D(`m ${24 + sineResult},2 ` + this.STATIC_STRING_HIGHLIGHT))
+    ctx.fill(this.cachedHighlightPath)
   }
 
   update() {


### PR DESCRIPTION
## Overview

This pull request ...
- Moves most of the `Path2D` objects created in the `render` function out to the `constructor`
- Extracts some calculations from `render` function
- Changes the target color that each color slider displays

## Compare

Rendering is ~3x faster than before.

<details><summary>30s performance test</summary>
<p>

before:
<img width="385" height="139" alt="image" src="https://github.com/user-attachments/assets/4c10a726-b4ea-4b7a-ad82-f5688ad1d0b0" />
after:
<img width="396" height="133" alt="image" src="https://github.com/user-attachments/assets/6f46f6ca-bec0-45bf-a47f-e831901d5d7d" />

render time calculating: js\scene\scene.js, class Scene
```js
render() {
  startRenderTiming() // start
  ctx.clearRect(0, 0, canvas.width, canvas.height)
  this.titleLogo.render({ colorModules: this.colorModules, sine: this.utilFunctions.sine, sine2: this.utilFunctions.sine2 })
  this.howToUseMsg.render()
  this.colorModules.forEach(module => module.render({ sine: this.utilFunctions.sine }))
  this.colorSliders.forEach(slider => slider.render({ colorModules: this.colorModules, sine: this.utilFunctions.sine }))
  digiPointer.render()
  endRenderTiming() // end
  this.update()
}
```

</p>
</details> 


